### PR TITLE
Microsoft Authenticator Plugin

### DIFF
--- a/MicrosoftAuthenticatorPlugin.cs
+++ b/MicrosoftAuthenticatorPlugin.cs
@@ -1,0 +1,93 @@
+//reference System.dll
+//reference System.Core.dll
+using System;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using MCGalaxy;
+using MCGalaxy.Authentication;
+
+namespace AuthPlugin
+{
+	public sealed class MicrosoftAuthenticationPlugin : Plugin
+	{
+		public override string name { get { return "MicrosoftAuthenticationPlugin"; } }
+		public override string MCGalaxy_Version { get { return "1.9.3.6"; } }
+
+		public override void Load(bool auto)
+		{
+			Authenticator.Current = new MicrosoftFallbackAuthenticator(Authenticator.Current);
+		}
+
+		public override void Unload(bool auto)
+		{
+			Authenticator.Current = ((MicrosoftFallbackAuthenticator)Authenticator.Current).underlyingAuthenticator;
+		}
+	}
+
+    class MicrosoftFallbackAuthenticator : Authenticator
+    {
+		// underlyingAuthenticator is used to allow the plugin to wrap an already wrapped authenticator if there is one.
+		// In addition, the default authenticator is sealed, and so cannot be inherited / extended.
+		public readonly Authenticator underlyingAuthenticator;
+		private readonly string externalIP; //TODO: Move this out.
+
+		public MicrosoftFallbackAuthenticator(Authenticator underlyingAuthenticator)
+        {
+			this.underlyingAuthenticator = underlyingAuthenticator;
+			externalIP = new WebClient().DownloadString("http://icanhazip.com").Replace("\\r\\n", "").Replace("\\n", "").Trim();
+		}
+
+        public override bool HasPassword(string name)
+        {
+			return underlyingAuthenticator.HasPassword(name);
+        }
+
+        public override bool ResetPassword(string name)
+        {
+			return underlyingAuthenticator.ResetPassword(name);
+        }
+
+        public override void StorePassword(string name, string password)
+        {
+			underlyingAuthenticator.StorePassword(name, password);
+		}
+
+        public override bool VerifyPassword(string name, string password)
+        {
+			return underlyingAuthenticator.VerifyPassword(name, password);
+        }
+
+		public override bool VerifyLogin(Player p, string mppass)
+		{
+			bool mppass_valid = base.VerifyLogin(p, mppass);
+			if (mppass_valid) return true;
+
+			string serverId = externalIP + ":" + Server.Config.Port;
+			var hash = new SHA1Managed().ComputeHash(Encoding.UTF8.GetBytes(serverId));
+			serverId = string.Concat(hash.Select(b => b.ToString("x2")));
+
+			// Check if the player has authenticated with Mojang's session server.
+			if (!hasJoined(p.truename, serverId)) return false;
+
+			p.verifiedName = true;
+			return true;
+		}
+
+		private bool hasJoined(string username, string serverId)
+		{
+			try
+			{
+				HttpWebRequest request = (HttpWebRequest)WebRequest.Create("https://sessionserver.mojang.com/session/minecraft/hasJoined?username=" + username + "&serverId=" + serverId);
+				HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+				return response.StatusCode == HttpStatusCode.OK;
+			} catch (Exception ex)
+            {
+				Logger.LogError(ex);
+            }
+
+			return false;
+		}
+	}
+}

--- a/MicrosoftAuthenticatorPlugin.cs
+++ b/MicrosoftAuthenticatorPlugin.cs
@@ -36,7 +36,7 @@ namespace AuthPlugin
 		public MicrosoftFallbackAuthenticator(Authenticator underlyingAuthenticator)
         {
 			this.underlyingAuthenticator = underlyingAuthenticator;
-			externalIP = new WebClient().DownloadString("http://icanhazip.com").Replace("\\r\\n", "").Replace("\\n", "").Trim();
+			externalIP = new WebClient().DownloadString("http://ipv4.icanhazip.com").Replace("\\r\\n", "").Replace("\\n", "").Trim();
 		}
 
         public override bool HasPassword(string name)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Some custom commands and plugins for MCGalaxy.
 | **Reward** | Allows using /Reward in Message Blocks, which will give the player money when clicked on.
 | **SchematicImporter** | Imports [Schematic](https://minecraft.fandom.com/wiki/Schematic_file_format) files from /extra/import.
 | **TeamChat** | Allows using *=message* as shortcut for */team message*.
+| **MicrosoftAuthentication** | Allows users to authenticate using the online-mode protocol, if verify-names fails or no mppass is provided.
 
 
 ## Other plugins available


### PR DESCRIPTION
This plugin allows the authenticator to fallback to release Minecraft's "online-mode" authentication if the classic verify-names protocol fails.

Online mode works as follows:
1. The client sends a web request to Mojang with their session token and the server which they are joining.
2. The server sends a web request to Mojang with the player's username, verifying that they are authenticated.

This is useful for early versions of classic (0.0.15 and 0.0.16) which do not support the verify-names protocol.
It is also useful for servers which do not wish to be listed, and therefore have no mp pass provider API.

To make use of this functionality a third party launcher must be used with an open join request. Fortunately, it is good practice for launchers implementing mppass providers to leave an open join request in the case that no mp pass is found, so MineOnline already supports this, and if Betacraft doesn't, it's a small change to implement.

Sorry the indents are messed up, my IDE keeps doing horrible things to the spacings. Compiles and works fine, though.